### PR TITLE
Reload payments so order has updated pending_payments

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -112,6 +112,8 @@ Spree::Order.class_eval do
     else
       other_payment.update_attributes!(amount: amount)
     end
+
+    payments.reload
   end
 
   def create_store_credit_payment(payment_method, credit, amount)


### PR DESCRIPTION
This change is necessary to avoid stale payments on order.
With orders that have an existing credit card payment and store credit,
the invalidated card payment is not picked up in `process_payments!` and
it ends up being processed.

This was fixed in Solidus in this change
https://github.com/solidusio/solidus/commit/1428d2d9e8b10664398a1eff3ca40ea548b43343
